### PR TITLE
Import base-64 encoded attributse

### DIFF
--- a/lib/ntospider/vuln.rb
+++ b/lib/ntospider/vuln.rb
@@ -27,7 +27,7 @@ module NTOSpider
         :vuln_type, :vuln_url, :web_site
         # nested tags
       ]
-end
+    end
 
     # This allows external callers (and specs) to check for implemented
     # properties

--- a/lib/ntospider/vuln.rb
+++ b/lib/ntospider/vuln.rb
@@ -93,18 +93,15 @@ module NTOSpider
       result.gsub!(/&gt;/, '>')
 
       result.gsub!(/<b>(.*?)<\/b>/, '*\1*')
-      result.gsub!(/<br\/>/, "\n")
-      result.gsub!(/<br>/, "\n")
+      result.gsub!(/<br\/?>/, "\n")
       result.gsub!(/<font.*?>(.*?)<\/font>/m, '\1')
       result.gsub!(/<h2>(.*?)<\/h2>/, '*\1*')
       result.gsub!(/<i>(.*?)<\/i>/, '\1')
       result.gsub!(/<p>(.*?)<\/p>/m, '\1')
       result.gsub!(/<pre.*?>(.*?)<\/pre>/m){|m| "\n\nbc.. #{ $1 }\n\np.  \n" }
 
-      result.gsub!(/<ul>/, "\n")
-      result.gsub!(/<\/ul>/, "\n")
-      result.gsub!(/<li>/, "\n* ")
-      result.gsub!(/<\/li>/, "\n")
+      result.gsub!(/<\/?ul>/, "\n")
+      result.gsub!(/<\/?li>/, "\n")
 
       result
     end

--- a/templates/vuln.fields
+++ b/templates/vuln.fields
@@ -3,6 +3,9 @@ vuln.attack_score
 vuln.attack_type
 vuln.attack_value
 vuln.capec
+vuln.crawl_traffic
+vuln.crawl_traffic_template
+vuln.crawl_traffic_response
 vuln.cwe_id
 vuln.description
 vuln.dissa_asc

--- a/templates/vuln.template
+++ b/templates/vuln.template
@@ -42,3 +42,12 @@
 
 #[OVAL]#
 %vuln.oval%
+
+#[Crawl Traffic]#
+%vuln.crawl_traffic%
+
+#[Crawl Traffic Template]#
+%vuln.crawl_traffic_template%
+
+#[Crawl Traffic Response]#
+%vuln.crawl_traffic_response%


### PR DESCRIPTION
Some `<Vuln>`s in the XML contain attributes called `<CrawlTraffic>`, `<CrawlTrafficTemplate>` and `<CrawlTrafficResponse>`, which contain base-64 encoded data. This PR updates the importer so it now imports this data.
