### PR TITLE
Fix Thor task for Pro edition and bump tiny version number

### DIFF
--- a/lib/dradis/plugins/ntospider/gem_version.rb
+++ b/lib/dradis/plugins/ntospider/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 1
-        TINY = 1
+        TINY = 2
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -17,13 +17,13 @@ class NTOSpiderTasks < Thor
 
     content_service = nil
     template_service = nil
+
+    template_service = Dradis::Plugins::TemplateService.new(plugin: Dradis::Plugins::NTOSpider)
     if defined?(Dradis::Pro)
       detect_and_set_project_scope
       content_service = Dradis::Pro::Plugins::ContentService.new(plugin: Dradis::Plugins::NTOSpider)
-      template_service = Dradis::Pro::Plugins::TemplateService.new(plugin: Dradis::Plugins::NTOSpider)
     else
       content_service = Dradis::Plugins::ContentService.new(plugin: Dradis::Plugins::NTOSpider)
-      template_service = Dradis::Plugins::TemplateService.new(plugin: Dradis::Plugins::NTOSpider)
     end
 
     importer = Dradis::Plugins::NTOSpider::Importer.new(


### PR DESCRIPTION
Uploading an NTO Spider file in the command line on the Pro edition (through the Thor task) currently throws the following error: 

`uninitialized constant Dradis::Pro::Plugins::TemplateService (NameError)`

This fix resolves the error and also increases the tiny version number for the add-on